### PR TITLE
chore: Fix test hang due to open connection

### DIFF
--- a/src/amqp-gateway.spec.ts
+++ b/src/amqp-gateway.spec.ts
@@ -18,6 +18,7 @@ const WAIT_TIME = 500;
 
 describe('AmqpGateway', function () {
   let queueName: string;
+  let gateway: AmqpGateway;
   let connection: ChannelModel, channel: Channel;
   let channelProvider: DefaultChannelProvider;
   let eventChannel: AmqpChannel;
@@ -32,6 +33,9 @@ describe('AmqpGateway', function () {
   });
 
   afterEach(async function () {
+    if (gateway) {
+      await gateway.stop();
+    }
     await channel.deleteQueue(queueName);
     await channel.close();
     await connection.close();
@@ -40,7 +44,7 @@ describe('AmqpGateway', function () {
 
   it('should receive events and send them to the handler', async function () {
     const handler = fake();
-    const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+    gateway = new AmqpGateway({ channelProvider, handler, queueName });
 
     const event = await new EventBuilder().create();
     await eventChannel.send(event);
@@ -54,7 +58,7 @@ describe('AmqpGateway', function () {
     channel = spy(channel);
     channelProvider = new DefaultChannelProvider({ channel });
     const handler = fake();
-    const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+    gateway = new AmqpGateway({ channelProvider, handler, queueName });
 
     const event = await new EventBuilder().create();
     await eventChannel.send(event);
@@ -66,7 +70,7 @@ describe('AmqpGateway', function () {
 
   it('should continue processing messages after an error', async function () {
     const handler = stub().onFirstCall().throws(new Error('Handler error'));
-    const gateway = new AmqpGateway({
+    gateway = new AmqpGateway({
       channelProvider,
       handler,
       queueName,
@@ -95,7 +99,7 @@ describe('AmqpGateway', function () {
         expect(JSON.parse(message.content.toString())).to.deep.equal(event);
       };
 
-      const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+      gateway = new AmqpGateway({ channelProvider, handler, queueName });
       gateway.on('message:received', listener);
 
       await eventChannel.send(event);
@@ -109,7 +113,7 @@ describe('AmqpGateway', function () {
 
       const handler = fake();
       const listener = fake();
-      const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+      gateway = new AmqpGateway({ channelProvider, handler, queueName });
       gateway.on('event:received', listener);
 
       await gateway.start();
@@ -125,7 +129,7 @@ describe('AmqpGateway', function () {
 
       const handler = fake.returns(result);
       const listener = fake();
-      const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+      gateway = new AmqpGateway({ channelProvider, handler, queueName });
       gateway.on('event:processed', listener);
 
       await gateway.start();
@@ -141,7 +145,7 @@ describe('AmqpGateway', function () {
 
       const handler = fake.returns(result);
       const listener = fake();
-      const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+      gateway = new AmqpGateway({ channelProvider, handler, queueName });
       gateway.on('message:processed', listener);
 
       await gateway.start();
@@ -160,7 +164,7 @@ describe('AmqpGateway', function () {
 
       const handler = fake();
       const listener = fake();
-      const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+      gateway = new AmqpGateway({ channelProvider, handler, queueName });
       gateway.on('message:acknowledged', listener);
 
       await gateway.start();
@@ -180,7 +184,7 @@ describe('AmqpGateway', function () {
 
       const handler = fake();
       const listener = fake();
-      const gateway = new AmqpGateway({
+      gateway = new AmqpGateway({
         channelProvider,
         handler,
         queueName,
@@ -201,7 +205,7 @@ describe('AmqpGateway', function () {
 
       const handler = fake.throws(error);
       const listener = fake();
-      const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+      gateway = new AmqpGateway({ channelProvider, handler, queueName });
       gateway.on('event:error', listener);
 
       await gateway.start();
@@ -217,7 +221,7 @@ describe('AmqpGateway', function () {
 
       const handler = fake.throws(error);
       const listener = fake();
-      const gateway = new AmqpGateway({ channelProvider, handler, queueName });
+      gateway = new AmqpGateway({ channelProvider, handler, queueName });
       gateway.on('message:error', listener);
 
       await gateway.start();

--- a/src/default-channel-provider.spec.ts
+++ b/src/default-channel-provider.spec.ts
@@ -33,6 +33,8 @@ describe('DefaultChannelProvider', function () {
       const channel = await provider.get();
       expect(channel.constructor.name).to.equal('Channel');
       expect(channel.connection.constructor.name).to.equal('Connection');
+      await channel.close();
+      await provider.stop();
     });
   });
 
@@ -44,6 +46,8 @@ describe('DefaultChannelProvider', function () {
       const channel = await provider.get();
       expect(channel.constructor.name).to.equal('Channel');
       expect(channel.connection.constructor.name).to.equal('Connection');
+      await channel.close();
+      await provider.stop();
     });
   });
 });

--- a/src/default-channel-provider.ts
+++ b/src/default-channel-provider.ts
@@ -76,4 +76,15 @@ export class DefaultChannelProvider
 
     return this.#connection;
   }
+
+  async stop() {
+    if (this.#channel) {
+      await this.#channel.close();
+      this.#channel = undefined;
+    }
+    if (this.#connection) {
+      await this.#connection.close();
+      this.#connection = undefined;
+    }
+  }
 }


### PR DESCRIPTION
Resolve an issue in tests where an open connection caused them to hang by ensuring proper closure of the gateway and channel resources after each test.